### PR TITLE
Changed the binding to use the Analytics namespace instead of just GAMP

### DIFF
--- a/src/Facades/GAMP.php
+++ b/src/Facades/GAMP.php
@@ -31,6 +31,6 @@ class GAMP extends Facade
      */
     protected static function getFacadeAccessor()
     {
-        return 'gamp';
+        return 'TheIconic\Tracking\GoogleAnalytics\Analytics';
     }
 }

--- a/src/LaravelGAMPServiceProvider.php
+++ b/src/LaravelGAMPServiceProvider.php
@@ -66,7 +66,7 @@ class LaravelGAMPServiceProvider extends ServiceProvider
      */
     public function registerAnalytics()
     {
-        $this->app->singleton('gamp', function ($app) {
+        $this->app->singleton('TheIconic\Tracking\GoogleAnalytics\Analytics', function ($app) {
             $config = $app['config'];
 
             $analytics = new Analytics($config->get('gamp.is_ssl', false));
@@ -93,6 +93,6 @@ class LaravelGAMPServiceProvider extends ServiceProvider
      */
     public function provides()
     {
-        return ['gamp'];
+        return ['TheIconic\Tracking\GoogleAnalytics\Analytics'];
     }
 }


### PR DESCRIPTION
I switched the bindings over to bind to the full Analytics class instead of just gamp. This fixed IDE auto-completion issues I was having with Dependency Injection, possibly same as #2 .

Facade still works as expected, but this will break previous code using DI.