### PR TITLE
Tracking ID from .env

### DIFF
--- a/src/config/gamp.php
+++ b/src/config/gamp.php
@@ -13,7 +13,7 @@ return [
     | https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#tid
     |
     */
-    'tracking_id' => 'UA-XXXX-Y',
+    'tracking_id' => env('GA_ID'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
This way we don't have to publish the config file and have the possibility to have different ID's per environment.