### PR TITLE
Async by default

### DIFF
--- a/src/config/gamp.php
+++ b/src/config/gamp.php
@@ -92,5 +92,5 @@ return [
     | Valid Values: (Boolean) "true" OR "false"
     |
     */
-    'async_requests' => false,
+    'async_requests' => true,
 ];


### PR DESCRIPTION
As non blocking is better in case Google is slow.